### PR TITLE
refs/tags/ is not required

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,7 +14,7 @@ TAG=$5
 
 docker pull quay.io/keboola/developer-portal-cli-v2:latest      
 
-export TARGET_TAG=`echo $TAG | /usr/bin/pcregrep -o1 '^refs/tags/(v?[0-9]+.[0-9]+.[0-9]+)$'`
+export TARGET_TAG=`echo $TAG | /usr/bin/pcregrep -o2 '^(refs/tags/)?(v?[0-9]+.[0-9]+.[0-9]+)$'`
 if [ "$TARGET_TAG" = "" ]
 then
     echo "Skipping deployment to Keboola Connection, tag ${TAG} is not allowed."


### PR DESCRIPTION
refs/tags/ se z nového workflow neposílá - kvůli zpětné kompatibilitě necháme nepovinné

posílá se:
<img width="957" alt="image" src="https://user-images.githubusercontent.com/12143866/130687502-94dd394b-2a57-475c-8bd1-813fc9ab4195.png">

před změnou:
<img width="776" alt="image" src="https://user-images.githubusercontent.com/12143866/130687604-0743c7ab-f1bb-454c-b979-d129abd14356.png">


po změně:
<img width="1024" alt="image" src="https://user-images.githubusercontent.com/12143866/130687559-e8994fcc-0013-43da-aa72-9b10d668a391.png">
